### PR TITLE
Customize news age window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # event-trader
+
+### Configuration
+
+Set `NEWS_MAX_AGE_HOURS` to control how far back the bot will look when
+scanning RSS feeds. It defaults to **12** hours. Increase this if the script
+is not run often and you want older headlines to be considered.

--- a/event_trader.py
+++ b/event_trader.py
@@ -54,6 +54,7 @@ TOTAL_CAPITAL_EUR = 1000
 MAX_POSITION_PCT = 0.05
 CONF_THRESHOLD = 60
 EURUSD_FX_RATE = 1.08
+NEWS_MAX_AGE_HOURS = int(os.getenv("NEWS_MAX_AGE_HOURS", "12"))
 
 try:
     with open("whitelisted_accounts.json", "r") as f:
@@ -142,7 +143,7 @@ def fetch_news():
                         print(f"[{url}] Date parse failed: {e.published} ({ex})")
                         continue
                     now = dt.utcnow().replace(tzinfo=pytz.UTC)
-                    if (now - published).total_seconds() > 6 * 3600:
+                    if (now - published).total_seconds() > NEWS_MAX_AGE_HOURS * 3600:
                         continue
                 yield e.title, getattr(e, "summary", "")
         except Exception as e:


### PR DESCRIPTION
## Summary
- expose `NEWS_MAX_AGE_HOURS` env var to tune how old RSS headlines can be
- document new setting in the README

## Testing
- `python -m py_compile event_trader.py`

------
https://chatgpt.com/codex/tasks/task_e_6870e772bca4832e9a41cc628250de3e