### PR TITLE
Add heartbeat messages on idle cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 Set `NEWS_MAX_AGE_HOURS` to control how far back the bot will look when
 scanning RSS feeds. It defaults to **12** hours. Increase this if the script
 is not run often and you want older headlines to be considered.
+
+When a processing cycle finds no trading opportunities, the bot sends a
+"heartbeat" notification to Telegram (or logs to stdout) so you know it is
+still running.

--- a/event_trader.py
+++ b/event_trader.py
@@ -272,4 +272,6 @@ if __name__ == "__main__":
     print("[EventTrader v0.9] running with Twitter + JSON whitelist + Gemini fallback")
     while True:
         found = process()
+        if not found:
+            tg("Heartbeat: no trades generated")
         time.sleep(600)


### PR DESCRIPTION
## Summary
- send heartbeat notification if no trade signals are produced
- document heartbeat in README

## Testing
- `python -m py_compile event_trader.py`
- `python test_signal.py` *(fails: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_6874cf3e5178832eab88180955e55511